### PR TITLE
Improve Clojure Syntax support

### DIFF
--- a/themes/gruvbox-material-dark.json
+++ b/themes/gruvbox-material-dark.json
@@ -2286,6 +2286,13 @@
       }
     },
     {
+      "name": "Clojure green",
+      "scope": "variable, support.variable.clojure, meta.definition.variable.clojure",
+      "settings": {
+        "foreground": "#a9b665"
+      }
+    },
+    {
       "name": "TOML orange",
       "scope": "keyword.key.toml",
       "settings": {


### PR DESCRIPTION
Clojure language use too much symbols and by having the same color for symbols and vars make it harder for the eyes

before
![image](https://user-images.githubusercontent.com/213964/100236698-c4097800-2f0c-11eb-9b82-b40a4629a071.png)

after
![image](https://user-images.githubusercontent.com/213964/100236623-aa683080-2f0c-11eb-9c0e-5045852836b9.png)
