### PR TITLE
improve syntax for clojure lang

### DIFF
--- a/src/syntax/default.ts
+++ b/src/syntax/default.ts
@@ -2162,6 +2162,15 @@ export function getDefaultSyntax(palette: Palette, italicComments: boolean) {
       },
     },
     // }}}
+    // CLOJURE{{{
+    {
+      name: "Clojure green",
+      scope: "variable, support.variable.clojure, meta.definition.variable.clojure",
+      settings: {
+        foreground: palette.green,
+      },
+    },
+    // }}}
     // TOML{{{
     {
       name: "TOML orange",

--- a/src/syntax/italic.ts
+++ b/src/syntax/italic.ts
@@ -2231,6 +2231,15 @@ export function getItalicSyntax(palette: Palette, italicComments: boolean) {
       },
     },
     // }}}
+    // CLOJURE{{{
+    {
+      name: "Clojure green",
+      scope: "variable, support.variable.clojure, meta.definition.variable.clojure",
+      settings: {
+        foreground: palette.green,
+      },
+    },
+    // }}}
     // TOML{{{
     {
       name: "TOML orange",


### PR DESCRIPTION
Clojure language use too much symbols and by having the same color for symbols and vars make it harder for the eyes

before
![100236698-c4097800-2f0c-11eb-9b82-b40a4629a071](https://user-images.githubusercontent.com/213964/100461700-ed124000-30a7-11eb-8937-55c63807d17e.png)


after
![100236623-aa683080-2f0c-11eb-9c0e-5045852836b9](https://user-images.githubusercontent.com/213964/100461729-f26f8a80-30a7-11eb-9d9b-de3a1eafd619.png)
