### PR TITLE
Support remote development by specifying extensionKind

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
     "type": "git",
     "url": "https://github.com/sainnhe/gruvbox-material-vscode.git"
   },
+  "extensionKind": [
+    "ui",
+    "workspace"
+  ],
   "activationEvents": [
     "*"
   ],


### PR DESCRIPTION
This extension does not specify `extensionKind`. It is treated as a `workspace` extension by default meaning it needs to be reinstalled on remote workspaces. See https://code.visualstudio.com/api/advanced-topics/remote-extensions#incorrect-execution-location for more information. This pull request sets `extensionKind` so that it prefers to run as a `ui` extension.