### PR TITLE
Add semantic colors for Rust enums

### DIFF
--- a/src/semantic/default.ts
+++ b/src/semantic/default.ts
@@ -47,6 +47,8 @@ export function getDefaultSemantic(palette: Palette) {
     "macro:rust": `${palette.aqua}`,
     "namespace:rust": `${palette.purple}`,
     "selfKeyword:rust": `${palette.purple}`,
+    "enum:rust": `${palette.purple}`,
+    "enumMember:rust": `${palette.blue}`,
     // }}}
   };
 }


### PR DESCRIPTION
|Before|After|
| ---- | --- |
|<img width="851" height="620" alt="Screenshot From 2025-07-13 18-23-06" src="https://github.com/user-attachments/assets/bc58ba55-67ec-43a2-ae44-b2136006cb80" />|<img width="851" height="620" alt="Screenshot From 2025-07-13 18-00-43" src="https://github.com/user-attachments/assets/aba1e0c4-eacf-4e22-9322-56ee0690db97" />|

Colors copied from Typescript

The enum member and variable(`other`) in match can now be distinguished